### PR TITLE
fixed issue #25 full international character support utf-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,9 @@ During autoInstallBundle, all JS and SCSS are concatenated, minified, and instal
 3. In `ui.apps` run `gulp`.
 4. Start buidling great things in `ui.apps/src/main/resources/jcr_root/etc/slick/designs/...`
 5. You can also specify arguments when running gulp. Example: `$ gulp --slingHost='slick.millr.org' --slingPort=8181 --slingPass=MySuperPassword --slingUser=cmillar`
+
+# international characters suppurt (UTF8 readyness)
+blogposts, comments and commentor names can have international characters
+
+
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It's built on top of Sling, HTL, Oak, OSGi and many other frameworks common to A
 * Pagination
 * Basic Localization
 * Comment support with ReCAPTCHA
+* International Language Support (UTF-8 Readiness)
 
 # Requirements
 * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
@@ -124,9 +125,3 @@ During autoInstallBundle, all JS and SCSS are concatenated, minified, and instal
 3. In `ui.apps` run `gulp`.
 4. Start buidling great things in `ui.apps/src/main/resources/jcr_root/etc/slick/designs/...`
 5. You can also specify arguments when running gulp. Example: `$ gulp --slingHost='slick.millr.org' --slingPort=8181 --slingPass=MySuperPassword --slingUser=cmillar`
-
-# international characters support (UTF8 readiness)
-blogposts, comments and commentor names can have international characters
-
-
-

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ During autoInstallBundle, all JS and SCSS are concatenated, minified, and instal
 4. Start buidling great things in `ui.apps/src/main/resources/jcr_root/etc/slick/designs/...`
 5. You can also specify arguments when running gulp. Example: `$ gulp --slingHost='slick.millr.org' --slingPort=8181 --slingPass=MySuperPassword --slingUser=cmillar`
 
-# international characters suppurt (UTF8 readyness)
+# international characters support (UTF8 readiness)
 blogposts, comments and commentor names can have international characters
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -240,6 +240,12 @@
             <version>1.0.2</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/core/src/main/java/org/millr/slick/servlets/comment/EditComment.java
+++ b/core/src/main/java/org/millr/slick/servlets/comment/EditComment.java
@@ -62,7 +62,10 @@ public class EditComment extends SlingAllMethodsServlet {
     DispatcherService dispatcherService;
     
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException{
-        LOGGER.info(">>>> Entering doPost");
+		request.setCharacterEncoding("UTF-8");
+    		// response.setContentType("text/html; charset=UTF-8");
+    		response.setCharacterEncoding("UTF-8");
+    		LOGGER.info(">>>> Entering doPost");
         
         // Get our parent resource
         Resource postResource = request.getResource();
@@ -77,6 +80,7 @@ public class EditComment extends SlingAllMethodsServlet {
             captchaValid = true;
         } else {
             String remoteIp = request.getRemoteAddr();
+            LOGGER.info(">>EditComment validateCaptcha " + remoteIp);
             captchaValid = validateCaptcha(request.getParameter("g-recaptcha-response"), remoteIp);
         }
         
@@ -86,7 +90,7 @@ public class EditComment extends SlingAllMethodsServlet {
         String responseMessage;
         JSONObject responseContent = new JSONObject();
         
-        String author = request.getParameter("author");
+        String author  = request.getParameter("author");
         String comment = request.getParameter("comment");
         
         

--- a/core/src/main/java/org/millr/slick/servlets/comment/EditComment.java
+++ b/core/src/main/java/org/millr/slick/servlets/comment/EditComment.java
@@ -14,7 +14,6 @@ import javax.jcr.nodetype.NodeType;
 import javax.servlet.ServletException;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.CharEncoding;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.JcrConstants;

--- a/core/src/main/java/org/millr/slick/servlets/comment/EditComment.java
+++ b/core/src/main/java/org/millr/slick/servlets/comment/EditComment.java
@@ -14,6 +14,7 @@ import javax.jcr.nodetype.NodeType;
 import javax.servlet.ServletException;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.CharEncoding;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.JcrConstants;
@@ -33,6 +34,7 @@ import org.millr.slick.services.UiMessagingService;
 import org.millr.slick.utils.Externalizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.CharEncoding;
 
 @SlingServlet(
         resourceTypes = "sling/servlet/default",
@@ -62,9 +64,9 @@ public class EditComment extends SlingAllMethodsServlet {
     DispatcherService dispatcherService;
     
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException{
-		request.setCharacterEncoding("UTF-8");
+    	request.setCharacterEncoding(CharEncoding.UTF_8);
     		// response.setContentType("text/html; charset=UTF-8");
-    		response.setCharacterEncoding("UTF-8");
+    		response.setCharacterEncoding(CharEncoding.UTF_8);
     		LOGGER.info(">>>> Entering doPost");
         
         // Get our parent resource
@@ -90,7 +92,7 @@ public class EditComment extends SlingAllMethodsServlet {
         String responseMessage;
         JSONObject responseContent = new JSONObject();
         
-        String author  = request.getParameter("author");
+        String author = request.getParameter("author");
         String comment = request.getParameter("comment");
         
         

--- a/core/src/main/java/org/millr/slick/servlets/item/EditItemServlet.java
+++ b/core/src/main/java/org/millr/slick/servlets/item/EditItemServlet.java
@@ -82,7 +82,10 @@ public class EditItemServlet extends SlingAllMethodsServlet {
 	
 	@Override
 	protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {
-		LOGGER.debug(">>>> Entering doPost");
+	// response.setContentType("text/html; charset=UTF-8");
+	// response.setCharacterEncoding("UTF-8");
+	request.setCharacterEncoding("UTF-8");
+	LOGGER.debug(">>>> Entering doPost");
 		
 		resolver = request.getResourceResolver();
 		session = resolver.adaptTo(Session.class);
@@ -91,7 +94,7 @@ public class EditItemServlet extends SlingAllMethodsServlet {
 		final String name = request.getParameter("nodeName");
 		final String content = request.getParameter("content");
 		final String description = request.getParameter("description");
-		final String[] tags = request.getParameterValues("tags");
+		final String[] tags =  request.getParameterValues("tags");
 		final String slickType = request.getParameter("slickType");
 		final String resourceType = slickType.substring(0, slickType.length()-1);
 		final String publishString = request.getParameter("publishDate");

--- a/core/src/main/java/org/millr/slick/servlets/item/EditItemServlet.java
+++ b/core/src/main/java/org/millr/slick/servlets/item/EditItemServlet.java
@@ -51,6 +51,7 @@ import org.millr.slick.services.UploadService;
 import org.millr.slick.utils.Externalizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.CharEncoding;
 
 @SlingServlet(
 	    resourceTypes = "sling/servlet/default",
@@ -84,7 +85,7 @@ public class EditItemServlet extends SlingAllMethodsServlet {
 	protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {
 	// response.setContentType("text/html; charset=UTF-8");
 	// response.setCharacterEncoding("UTF-8");
-	request.setCharacterEncoding("UTF-8");
+	request.setCharacterEncoding(CharEncoding.UTF_8);
 	LOGGER.debug(">>>> Entering doPost");
 		
 		resolver = request.getResourceResolver();
@@ -94,7 +95,7 @@ public class EditItemServlet extends SlingAllMethodsServlet {
 		final String name = request.getParameter("nodeName");
 		final String content = request.getParameter("content");
 		final String description = request.getParameter("description");
-		final String[] tags =  request.getParameterValues("tags");
+		final String[] tags = request.getParameterValues("tags");
 		final String slickType = request.getParameter("slickType");
 		final String resourceType = slickType.substring(0, slickType.length()-1);
 		final String publishString = request.getParameter("publishDate");

--- a/ui.apps/src/main/resources/jcr_root/apps/slick/author/item/edit/body.html
+++ b/ui.apps/src/main/resources/jcr_root/apps/slick/author/item/edit/body.html
@@ -4,6 +4,7 @@
         <sly data-sly-include="subNavigation.html"></sly>
         <div class="content">
             <form method="POST" action="item.edit.html" enctype="multipart/form-data">
+            <input type="hidden" name="_charset_" value="UTF-8"/>
                 <section id="title-section">
                     <input name="title" type="text" class="item-title" id="title" tabindex="1" placeholder="enter title" value="${editBlog.post.title}">
                     <div class="seo accent-background-light">

--- a/ui.apps/src/main/resources/jcr_root/apps/slick/publish/post/detail/body.html
+++ b/ui.apps/src/main/resources/jcr_root/apps/slick/publish/post/detail/body.html
@@ -61,7 +61,8 @@
                 </div>
                 <div class="comments-section" id="comments-section" data-sly-test="${view.page.enableComments}">
                     <div class="comments-list" id="comments-list"></div>
-                    <form class="comment-form" id="comment-form" action="${view.external.resourcePath}.edit.comment.json" method="POST">
+                    <form class="comment-form" id="comment-form" action="${view.external.resourcePath}.edit.comment.json" method="POST" enctype="multipart/form-data; UTF-8">
+            <input type="hidden" name="_charset_" value="UTF-8"/>
                         <input type="text" name="author" class="commentor-name" placeholder="name (optional)" />
                         <textarea name="comment" class="commentor-comment" placeholder="comment (plaintext)"></textarea>
                         <div class="Grid Fit-Small">


### PR DESCRIPTION
parts of slick were already UTF-8 ready but a few were still missing - leading sling to fallback to default ISO8859-1 - no _global_ changes in sling needed